### PR TITLE
Pr #15: Number # decimal number15 Aegis easter egg change

### DIFF
--- a/_maps/map_files/Aegis/Aegis.dmm
+++ b/_maps/map_files/Aegis/Aegis.dmm
@@ -21760,10 +21760,8 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "aRr" = (
-/obj/item/claymore/weak/ceremonial,
-/obj/item/clothing/under/kilt,
-/obj/item/clothing/head/beret,
-/obj/item/clothing/shoes/laceup,
+/obj/item/bodypart/l_leg,
+/obj/item/reagent_containers/food/snacks/salad/herbsalad,
 /turf/open/floor/plating,
 /area/hallway/secondary/command)
 "aRs" = (


### PR DESCRIPTION
Fifteen

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Replaced the secret easter egg by bridge on the Aegis map.

## Why It's Good For The Game

I dunno like easter eggs are not that important, but I think chances are people are less likely to cut someone with a salad than a claymore

## Changelog
:cl:
add: Implemented a cut off leg, and a salad
del: removed the cermonial scottish garb

/:cl:
![Number 15](https://user-images.githubusercontent.com/43185112/62842977-987e6200-bcb6-11e9-8b04-7258896c86a9.JPG)
